### PR TITLE
Added distro: Ubunto 20.10 "groovy"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ DISTROS= \
 	artful \
 	xenial \
 	trusty \
-	precise
+	precise \
+	groovy
 
 # Package name and version
 PACKAGE_NAME=$(shell python setup.py --name)


### PR DESCRIPTION
Fix for 
```
E: The repository 'http://ppa.launchpad.net/olipo186/git-auto-deploy/ubuntu groovy Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```